### PR TITLE
fix: typo

### DIFF
--- a/.github/scripts/get-path-prefix.js
+++ b/.github/scripts/get-path-prefix.js
@@ -97,7 +97,7 @@ module.exports = async ({ core, isStage, isProd }) => {
           `The pathPrefix in the site's config.md file was not found in the STAGE gdrive's devsitepaths.json.
 
           pathPrefix from config.md: "${pathPrefix}"
-          devsitepath.json location: "${DEVSITE_STAGE_HOST}/${DEVSITE_PATHNAME}"
+          devsitepath.json location: "${DEVSITE_STAGE_HOST}${DEVSITE_PATHNAME}"
 
           To fix this, make sure the pathPrefix listed in the config.md is in the devsitepath.json location.
           `


### PR DESCRIPTION
Fix typo by removing extra slash:
<img width="1449" alt="Screenshot 2025-03-20 at 12 03 58 PM" src="https://github.com/user-attachments/assets/2c973b81-257e-4008-bedd-7721b20608cf" />
