### PR TITLE
feat: improve renameFiles script

### DIFF
--- a/renameFiles.js
+++ b/renameFiles.js
@@ -123,9 +123,13 @@ try {
     files.forEach(file => {
         renameLinksInMarkdownFile(fileMap, file);
     });
-    renameLinksInRedirectsFile(fileMap);
-    appendRedirects(fileMap);
     renameFiles(fileMap);
+
+    const redirectsFile = getRedirectionsFilePath();
+    if(fs.existsSync(redirectsFile)) {
+        renameLinksInRedirectsFile(fileMap);
+        appendRedirects(fileMap);
+    }
 
 } catch (err) {
     console.error(err);

--- a/renameFiles.js
+++ b/renameFiles.js
@@ -118,9 +118,9 @@ function renameFiles(map) {
 }
 
 try {
-    const files = getMarkdownFiles();
-    const fileMap = getFileMap(files);
-    files.forEach(file => {
+    const markdownFiles = getMarkdownFiles();
+    const fileMap = getFileMap(markdownFiles);
+    markdownFiles.forEach(file => {
         renameLinksInMarkdownFile(fileMap, file);
     });
     renameFiles(fileMap);

--- a/renameFiles.js
+++ b/renameFiles.js
@@ -10,7 +10,9 @@ function getMarkdownFiles() {
 }
 
 function toKebabCase(str) {
-    return str && str
+    const isScreamingSnakeCase = new RegExp(/^[A-Z0-9_]*$/gm).test(str);
+    str = isScreamingSnakeCase ? str.toLowerCase() : str;
+    return str
         .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
         .map(x => x.toLowerCase())
         .join('-');

--- a/renameFiles.js
+++ b/renameFiles.js
@@ -90,7 +90,7 @@ function renameLinksInRedirectsFile(fileMap) {
     replaceLinksInFile({
         file,
         linkMap: getLinkMap(fileMap, dir),
-        getFindPattern: (from) => `(")(Source|Destination)("\\s*:\\s*")(${pathPrefix}${from})(#[^"]*)?(")`,
+        getFindPattern: (from) => `(['"]?)(Source|Destination)(['"]?\\s*:\\s*['"])(${pathPrefix}${from})(#[^'"]*)?(['"])`,
         getReplacePattern: (to) => `$1$2$3${pathPrefix}${to}$5$6`,
     });
 }

--- a/renameFiles.js
+++ b/renameFiles.js
@@ -95,6 +95,16 @@ function renameLinksInRedirectsFile(fileMap) {
     });
 }
 
+function renameLinksInGatsbyConfigFile(fileMap, file) {
+    const dir = 'src/pages';
+    replaceLinksInFile({
+        file,
+        linkMap: getLinkMap(fileMap, dir),
+        getFindPattern: (from) => `(['"]?path['"]?\\s*:\\s*['"])(/${from})(#[^'"]*)?(['"])`,
+        getReplacePattern: (to) => `$1/${to}$3$4`,
+    });
+}
+
 function appendRedirects(fileMap) {
     const file = getRedirectionsFilePath();
     const dir = path.dirname(file);
@@ -129,6 +139,11 @@ try {
     if(fs.existsSync(redirectsFile)) {
         renameLinksInRedirectsFile(fileMap);
         appendRedirects(fileMap);
+    }
+
+    const gatsbyConfigFile = 'gatsby-config.js';
+    if(fs.existsSync(gatsbyConfigFile)) {
+        renameLinksInGatsbyConfigFile(fileMap, gatsbyConfigFile);
     }
 
 } catch (err) {

--- a/renameFiles.js
+++ b/renameFiles.js
@@ -32,7 +32,7 @@ function toUrl(file, renameBaseWithoutExt) {
     return `${file.substring(0, end)}${newBaseWithoutExt}`
 }
 
-function toRelativeUrl(file, fromDir) {
+function toRelativeUrl(fromDir, file) {
     const relativeFile = path.relative(fromDir, file);
     return toUrl(relativeFile, f => f);
 }
@@ -57,8 +57,8 @@ function getFileMap(files) {
 function getLinkMap(fileMap, relativeToDir) {
     const linkMap = new Map();    
     fileMap.forEach((toFile, fromFile) => {
-        const fromUrl = toRelativeUrl(fromFile, relativeToDir);
-        const toUrl = toRelativeUrl(toFile, relativeToDir);
+        const fromUrl = toRelativeUrl(relativeToDir, fromFile);
+        const toUrl = toRelativeUrl(relativeToDir, toFile);
         linkMap.set(fromUrl, toUrl);
     });
     return linkMap;


### PR DESCRIPTION
## Description
Improve renameFiles script (uncovered while working with Davide's test):
- rename links in redirects.json if it exists
- rename links in gatsby-config.js if it exists. (This technically isn't really needed for EDS, but Davide wanted to test the renames first on Gatsby before moving to EDS. Since we already have this logic in place, might as well add it here in case other teams need it too).
- handle screaming snake case e.g. [CURRENT_PROTOCOL_VERSION](https://github.com/AdobeDocs/cc-everywhere/blob/a3cec7797cf70ec4cd0884a0f8e0ad2b2a0d79f1/src/pages/v4/shared/src/messenger/index.md?plain=1#L157). Previously this would get renamed to "C-U-R-R-E-N-T..." but now it'll get renamed to "current_protocol_version"
- handle single, double, or no quotes in redirects.json and gatbsy-config.js

## Related Issue
https://jira.corp.adobe.com/browse/DEVSITE-1627

## How Has This Been Tested?
1. devsite-1627-improve-rename-files-script-test
2. node renameFiles

## Screenshots

- Files renamed
<img width="560" alt="Screenshot 2025-04-15 at 2 18 43 PM" src="https://github.com/user-attachments/assets/f9e80fa8-69cb-4f5c-89cd-53d7203295de" />

- Links updated in markdown files
<img width="1127" alt="Screenshot 2025-04-15 at 2 18 25 PM" src="https://github.com/user-attachments/assets/d7e01d13-faa0-46d0-8e3e-dccf8bdd8275" />
<img width="1125" alt="Screenshot 2025-04-15 at 2 17 52 PM" src="https://github.com/user-attachments/assets/a92a5045-d5b4-453f-b940-372377ed16f1" />

- Links updated in redirections file
<img width="1125" alt="Screenshot 2025-04-15 at 2 18 05 PM" src="https://github.com/user-attachments/assets/1daece49-a90b-416f-aca8-53a417e7373e" />

- Links updated in gatbsy-config file
<img width="1127" alt="Screenshot 2025-04-15 at 2 17 36 PM" src="https://github.com/user-attachments/assets/6b5b7bf5-2639-4151-8b98-a204509426c6" />
