### PR TITLE
feat: update renameFiles script according to new link standards

### DIFF
--- a/renameFiles.js
+++ b/renameFiles.js
@@ -32,11 +32,6 @@ function toUrl(file, renameBaseWithoutExt) {
     return `${file.substring(0, end)}${newBaseWithoutExt}`
 }
 
-function toRelativeUrl(fromDir, file) {
-    const relativeFile = path.relative(fromDir, file);
-    return toUrl(relativeFile, f => f);
-}
-
 function renameFile(file, renameBaseWithoutExt) {
     const url = toUrl(file, renameBaseWithoutExt);
     const ext = path.extname(file);
@@ -57,9 +52,9 @@ function getFileMap(files) {
 function getLinkMap(fileMap, relativeToDir) {
     const linkMap = new Map();    
     fileMap.forEach((toFile, fromFile) => {
-        const fromUrl = toRelativeUrl(relativeToDir, fromFile);
-        const toUrl = toRelativeUrl(relativeToDir, toFile);
-        linkMap.set(fromUrl, toUrl);
+        const fromRelFile = path.relative(relativeToDir, fromFile);
+        const toRelFile = path.relative(relativeToDir, toFile);
+        linkMap.set(fromRelFile, toRelFile);
     });
     return linkMap;
 }

--- a/renameFiles.js
+++ b/renameFiles.js
@@ -85,8 +85,8 @@ function renameLinksInRedirectsFile(fileMap) {
     replaceLinksInFile({
         file,
         linkMap: getLinkMap(fileMap, dir),
-        getFindPattern: (from) => `(['"]?)(Source|Destination)(['"]?\\s*:\\s*['"])(${pathPrefix}${from})(#[^'"]*)?(['"])`,
-        getReplacePattern: (to) => `$1$2$3${pathPrefix}${to}$5$6`,
+        getFindPattern: (from) => `(['"]?)(Source|Destination)(['"]?\\s*:\\s*['"])(${pathPrefix}${toUrl(from)})(#[^'"]*)?(['"])`,
+        getReplacePattern: (to) => `$1$2$3${pathPrefix}${toUrl(to)}$5$6`,
     });
 }
 
@@ -107,8 +107,8 @@ function appendRedirects(fileMap) {
     const newData = [];
     linkMap.forEach((to, from) => {
         newData.push({
-            Source:  `${pathPrefix}${from}`, 
-            Destination: `${pathPrefix}${to}`,
+            Source:  `${pathPrefix}${toUrl(from)}`, 
+            Destination: `${pathPrefix}${toUrl(to)}`,
         })
     });
     const currData = readRedirectionsFile();

--- a/renameFiles.js
+++ b/renameFiles.js
@@ -85,8 +85,8 @@ function renameLinksInRedirectsFile(fileMap) {
     replaceLinksInFile({
         file,
         linkMap: getLinkMap(fileMap, dir),
-        getFindPattern: (from) => `(['"]?)(Source|Destination)(['"]?\\s*:\\s*['"])(${pathPrefix}${toUrl(from)})(#[^'"]*)?(['"])`,
-        getReplacePattern: (to) => `$1$2$3${pathPrefix}${toUrl(to)}$5$6`,
+        getFindPattern: (from) => `(['"]?)(Source|Destination)(['"]?\\s*:\\s*['"])(${pathPrefix}${toUrl(from)})(/?)(#[^'"]*)?(['"])`,
+        getReplacePattern: (to) => `$1$2$3${pathPrefix}${toUrl(to)}$5$6$7`,
     });
 }
 

--- a/renameFiles.js
+++ b/renameFiles.js
@@ -23,7 +23,7 @@ function toEdsCase(str) {
     return isValid ? str : toKebabCase(str);
 }
 
-function toUrl(file, renameBaseWithoutExt) {
+function toUrl(file, renameBaseWithoutExt = name => name) {
     const base = path.basename(file);
     const ext = path.extname(file);
     const end = file.length - base.length;


### PR DESCRIPTION
### Description
Update renameFiles script to recognize links that follow our new standards (defined in https://jira.corp.adobe.com/browse/DEVSITE-1629?focusedId=47384586&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-47384586)

### Screenshots
Files renamed:
<img width="431" alt="Screenshot 2025-04-24 at 2 55 39 PM" src="https://github.com/user-attachments/assets/efea128a-7b3a-470c-a121-107a434aa32e" />

Redirect links renamed + bookmarks for old names added:
<img width="1333" alt="Screenshot 2025-04-24 at 2 57 29 PM" src="https://github.com/user-attachments/assets/5b2eede6-b19c-43a7-b08f-476dfd4be535" />

Config links renamed:
<img width="1254" alt="Screenshot 2025-04-24 at 2 55 55 PM" src="https://github.com/user-attachments/assets/c2f42395-6d57-4411-8e29-261e19028d7a" />

Markdown file links renamed:
<img width="1248" alt="Screenshot 2025-04-24 at 2 56 11 PM" src="https://github.com/user-attachments/assets/6abb0dec-3322-4ce6-a39a-945d94d89a44" />