### PR TITLE
fix: normalize anchor links

### DIFF
--- a/normalizeLinks.js
+++ b/normalizeLinks.js
@@ -21,7 +21,7 @@ function normalizeLinksInMarkdownFile(file, files) {
         // ensure link includes file name and extension
         const from = link[3] ?? '';
         let to = from;
-        if(to === '') {
+        if(link[2]?.endsWith('/') && to === '') {
             to = 'index.md';
         }
         if(to.endsWith('/')) {


### PR DESCRIPTION
## Description
Fix issue where `index.md` is incorrectly prepended to anchor links for current file.

## Related Issue
https://jira.corp.adobe.com/browse/DEVSITE-1562

## Test
1. git checkout devsite-1562-normalize-anchor-link-test
2. yarn normalizeLinks

## Before
<img width="1202" alt="Screenshot 2025-04-30 at 8 01 19 AM" src="https://github.com/user-attachments/assets/822a45ad-dacb-499f-9b97-f89da817e9eb" />
<img width="1202" alt="Screenshot 2025-04-30 at 8 01 36 AM" src="https://github.com/user-attachments/assets/e8f21e85-db0f-4ccc-b8c0-6437b1fdcd63" />

## After
<img width="1202" alt="Screenshot 2025-04-30 at 8 08 08 AM" src="https://github.com/user-attachments/assets/b1955df7-70f9-443e-8466-d89dc703915f" />
<img width="1203" alt="Screenshot 2025-04-30 at 8 08 13 AM" src="https://github.com/user-attachments/assets/f10b1a8e-85e7-4117-9ee4-fc5624eb0cb3" />

 
