### PR TITLE
feat: ensure relative paths are canonical

### DIFF
--- a/normalizeLinks.js
+++ b/normalizeLinks.js
@@ -17,11 +17,15 @@ function normalizeLinksInMarkdownFile(file, files) {
     let data = fs.readFileSync(file, 'utf8');
     const links = matchAll(data, new RegExp(linkPattern, "gm"));
     [...links].forEach(link => {
+        // ensure canonical relative path
+        const from = link[3] ?? '';
+        const absoluteFrom = path.resolve(relativeToDir, from);
+        const relativeFrom = path.relative(relativeToDir, absoluteFrom);
+        let to = relativeFrom;
 
         // ensure link includes file name and extension
-        const from = link[3] ?? '';
-        let to = from;
-        if(link[2]?.endsWith('/') && to === '') {
+        const optionalPrefix = link[2] ?? '';
+        if(optionalPrefix.endsWith('/') && to === '') {
             to = 'index.md';
         }
         if(to.endsWith('/')) {


### PR DESCRIPTION
## Description

Ensure relative paths are canonical (i.e. in the simplest form)

## Related Issue

https://jira.corp.adobe.com/browse/DEVSITE-1562

## Motivation and Context

**Issue:**

We've uncovered an edge case that wasn't being handled while using the scripts in express-add-on-docs.

There's two relative paths in [src/pages/references/changelog.md](https://github.com/AdobeDocs/express-add-ons-docs/blob/main/src/pages/references/changelog.md?plain=1) referencing [src/pages/references/document-sandbox/document-apis/classes/AddOnData.md](https://github.com/AdobeDocs/express-add-ons-docs/blob/main/src/pages/references/document-sandbox/document-apis/classes/AddOnData.md?plain=1):
- one is not canonical (notice the unnecessary `../references`):
```[AddOnData](../references/document-sandbox/document-apis/classes/AddOnData.md)```
- one is canonical: 
```[`AddOnData`](./document-sandbox/document-apis/classes/AddOnData.md)```

Running `yarn normalizeLinks; yarn renameFiles;` only renames the canonical relative path.

**Fix:**
Convert all relative paths to canonical form in `normalizeLinks` so that `renameFiles` can pick them up.

**Considerations:**
- Initially considered allowing non-canonical relative links, and doing a substring comparison on the links - but that can lead to false positives.
- Ended up enforcing canonical relative links, and doing a full string comparison on the links - which seems like a more robust solution.

## How Has This Been Tested?

1. cd to local copy of express-add-ons-docs
2. git checkout devsite-1562-canonical-relative-path-test
3. yarn normalizeLinks - notice this converts all relative paths to canonical form
<img width="1266" alt="Screenshot 2025-05-01 at 2 31 48 PM" src="https://github.com/user-attachments/assets/96d0d90c-6556-4158-9365-efdb8c0668c3" />
4. yarn renameFiles - notice that this now renames both instances AddOnData
<img width="1259" alt="Screenshot 2025-05-01 at 3 26 37 PM" src="https://github.com/user-attachments/assets/d829b871-686f-44a9-962a-c4bf87ddb4f2" />
<img width="1265" alt="Screenshot 2025-05-01 at 3 26 48 PM" src="https://github.com/user-attachments/assets/8963edb4-7a20-41a3-a242-f62e1d05fb75" />
