### PR TITLE
fix: trailing slash bug with normalizeLinks

### DIFF
--- a/normalizeLinks.js
+++ b/normalizeLinks.js
@@ -26,10 +26,7 @@ function normalizeLinksInMarkdownFile(file, files) {
         let to = relativeFrom;
 
         // ensure link includes file name and extension
-        if(optionalPrefix.endsWith('/') && to === '') {
-            to = 'index.md';
-        }
-        if(to.endsWith('/')) {
+        if(to.endsWith('/') || optionalPrefix.endsWith('/') && to === '') {
             to = `${to}index.md`
         }
         if(!to.endsWith('.md')) {

--- a/normalizeLinks.js
+++ b/normalizeLinks.js
@@ -25,7 +25,7 @@ function normalizeLinksInMarkdownFile(file, files) {
         if(to.endsWith('/') || optionalPrefix.endsWith('/') && to === '') {
             to = `${to}index.md`
         }
-        if(!to.endsWith('.md')) {
+        if(!to.endsWith('.md') && to !== '') {
             to = `${to}.md`;
         }
 

--- a/normalizeLinks.js
+++ b/normalizeLinks.js
@@ -19,11 +19,7 @@ function normalizeLinksInMarkdownFile(file, files) {
     [...links].forEach(link => {
         const optionalPrefix = link[2] ?? '';
         const from = link[3] ?? '';
-
-        // ensure canonical relative path
-        const absoluteFrom = path.resolve(relativeToDir, from);
-        const relativeFrom = path.relative(relativeToDir, absoluteFrom);
-        let to = relativeFrom;
+        let to = from;
 
         // ensure link includes file name and extension
         if(to.endsWith('/') || optionalPrefix.endsWith('/') && to === '') {
@@ -32,6 +28,12 @@ function normalizeLinksInMarkdownFile(file, files) {
         if(!to.endsWith('.md')) {
             to = `${to}.md`;
         }
+
+        // ensure simplest relative path
+        // this removes trailing slash, so need to do this after the file name and extension checks above
+        const absolute = path.resolve(relativeToDir, to);
+        const relative = path.relative(relativeToDir, absolute);
+        to = relative;
 
         // ensure the link we constructed above exists
         const toExists = relativeFiles.find(file => to === file);

--- a/normalizeLinks.js
+++ b/normalizeLinks.js
@@ -22,10 +22,10 @@ function normalizeLinksInMarkdownFile(file, files) {
         let to = from;
 
         // ensure link includes file name and extension
-        if(to.endsWith('/') || optionalPrefix.endsWith('/') && to === '') {
+        if(to.endsWith('/') || optionalPrefix.endsWith('/') && !to) {
             to = `${to}index.md`
         }
-        if(!to.endsWith('.md') && to !== '') {
+        if(!to.endsWith('.md') && to) {
             to = `${to}.md`;
         }
 

--- a/normalizeLinks.js
+++ b/normalizeLinks.js
@@ -17,14 +17,15 @@ function normalizeLinksInMarkdownFile(file, files) {
     let data = fs.readFileSync(file, 'utf8');
     const links = matchAll(data, new RegExp(linkPattern, "gm"));
     [...links].forEach(link => {
-        // ensure canonical relative path
+        const optionalPrefix = link[2] ?? '';
         const from = link[3] ?? '';
+
+        // ensure canonical relative path
         const absoluteFrom = path.resolve(relativeToDir, from);
         const relativeFrom = path.relative(relativeToDir, absoluteFrom);
         let to = relativeFrom;
 
         // ensure link includes file name and extension
-        const optionalPrefix = link[2] ?? '';
         if(optionalPrefix.endsWith('/') && to === '') {
             to = 'index.md';
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix bug where converting to simplest relative path removes trailing slash 
- introduced in https://github.com/AdobeDocs/adp-devsite-github-actions-test/pull/27
- Root cause was https://github.com/AdobeDocs/adp-devsite-github-actions-test/pull/28/files#diff-a9a854efbb67487b10ff18f8eb83f2554139427c7bd552fca5642f2859d78557R33

## Related Issue
https://jira.corp.adobe.com/browse/DEVSITE-1562

## How Has This Been Tested?
1. git checkout devsite-1562-file-name-and-ext-test
2. yarn normalizeLinks

## Screenshots (if appropriate):
### Test files
<img width="454" alt="files" src="https://github.com/user-attachments/assets/1df9ac1e-7dee-40e0-8671-31d3558d8bfa" />

### Before
<img width="1232" alt="before" src="https://github.com/user-attachments/assets/15fc2900-b83f-4bd7-9053-297da9c0e3f8" />

### After
<img width="1233" alt="after" src="https://github.com/user-attachments/assets/acc067ea-3f4d-47d8-af70-21befbfc9e5d" />
