### PR TITLE
fix: enforce / path separator even on Windows machine

### DIFF
--- a/normalizeLinks.js
+++ b/normalizeLinks.js
@@ -29,6 +29,8 @@ function normalizeLinksInMarkdownFile(file, files) {
             to = `${to}.md`;
         }
 
+        to = to.replaceAll('/', path.sep);
+
         // ensure simplest relative path
         // this removes trailing slash, so need to do this after the file name and extension checks above
         const absolute = path.resolve(relativeToDir, to);
@@ -37,6 +39,8 @@ function normalizeLinksInMarkdownFile(file, files) {
 
         // ensure the link we constructed above exists
         const toExists = relativeFiles.find(file => to === file);
+
+        to = to.replaceAll(path.sep, '/');
 
         if(to !== from && toExists) {
             linkMap.set(from, to);

--- a/renameFiles.js
+++ b/renameFiles.js
@@ -54,8 +54,12 @@ function getFileMap(files) {
 function getLinkMap(fileMap, relativeToDir) {
     const linkMap = new Map();    
     fileMap.forEach((toFile, fromFile) => {
-        const fromRelFile = path.relative(relativeToDir, fromFile);
-        const toRelFile = path.relative(relativeToDir, toFile);
+        let fromRelFile = path.relative(relativeToDir, fromFile);
+        fromRelFile = fromRelFile.replaceAll(path.sep, '/');
+
+        let toRelFile = path.relative(relativeToDir, toFile);
+        toRelFile = toRelFile.replaceAll(path.sep, '/');
+
         linkMap.set(fromRelFile, toRelFile);
     });
     return linkMap;
@@ -83,7 +87,7 @@ function renameLinksInRedirectsFile(fileMap) {
 }
 
 function renameLinksInGatsbyConfigFile(fileMap, file) {
-    const dir = 'src/pages';
+    const dir = path.join('src', 'pages');
     replaceLinksInFile({
         file,
         linkMap: getLinkMap(fileMap, dir),

--- a/scriptUtils.js
+++ b/scriptUtils.js
@@ -3,7 +3,8 @@ const fs = require('node:fs');
 const { globSync }= require('glob');
 
 function getRedirectionsFilePath() {
-    return path.resolve(__dirname + '/src/pages/redirects.json');
+    const redirectionsFilePath = path.join(__dirname, 'src', 'pages', 'redirects.json');
+    return path.resolve(redirectionsFilePath);
 }
 
 function readRedirectionsFile() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Modify `normalizeLinks` and `renameFiles` scripts so that they can be run on any platform, e.g. Windows, Mac.

## Related Issue

https://jira.corp.adobe.com/browse/DEVSITE-1633

## Motivation and Context

**Issue:**

Baskar discovered a couple issues when running `normalizeLinks`/`renameFiles` scripts on Windows machine:
- `normalizeLinks` replaces `/` (URI and Mac) separators with `\` (Windows) separator
![separator](https://github.com/user-attachments/assets/91903605-6a3c-4bdd-9746-eb7666cebf2b)

-  `renameFiles` replaces path separator with dash
![rename bug on windows](https://github.com/user-attachments/assets/5b9816d2-5681-44a8-8c92-66f4f73c1d2b)

**Fix:**
- When handling filenames, use local machine's separator (i.e. `/` for Mac,  `\` for Windows)
- When handling links, use URL separator (i.e. `/`)

## How Has This Been Tested?

Tested on both Mac and Windows machines.

1. cd to local copy of adp-devsite-github-actions-test
2. git checkout devsite-1562-path-separator-test
3. yarn normalizeLinks
4. Confirm that links have been changed to include file name + extension:
- <img width="541" alt="Screenshot 2025-05-05 at 9 16 37 PM" src="https://github.com/user-attachments/assets/5058447e-894d-4f26-bc08-245baa27ab08" />
- <img width="1146" alt="Screenshot 2025-05-05 at 9 16 48 PM" src="https://github.com/user-attachments/assets/89d5d8b4-3c1a-43fc-8526-360e6358ae4f" />
- <img width="1144" alt="Screenshot 2025-05-05 at 9 16 56 PM" src="https://github.com/user-attachments/assets/4c30ac41-c7bf-41e5-99f4-500073cbcc26" />
4. git add .; git commit -m "normalize links"
5. open up `redirects.json` > Format Document > save
6. git add .; git commit -m "format"
7. yarn renameFiles
8. open up `redirects.json` > Format Document > save
9. Confirm that files and their associated links have been renamed to kebab-case
- <img width="541" alt="Screenshot 2025-05-05 at 9 20 30 PM" src="https://github.com/user-attachments/assets/8cee3ccf-525d-4fad-ac19-bf205de671b9" />
- <img width="1149" alt="Screenshot 2025-05-05 at 9 20 36 PM" src="https://github.com/user-attachments/assets/ebc57156-0bcc-4e8b-933c-32727dba18a8" />
- <img width="1146" alt="Screenshot 2025-05-05 at 9 20 45 PM" src="https://github.com/user-attachments/assets/3a488cd7-538e-4203-afab-ba5bfc8230cd" />
- <img width="1149" alt="Screenshot 2025-05-05 at 9 21 24 PM" src="https://github.com/user-attachments/assets/04ce30b1-cc5f-4a9b-8815-2e7547a93df7" />


