### PR TITLE
feat: rename dirs

### DIFF
--- a/renameFiles.js
+++ b/renameFiles.js
@@ -94,6 +94,16 @@ function getLinkMap(fileMap, relativeToDir) {
     return linkMap;
 }
 
+function renameLinksInGatsbyConfigFile(fileMap, file) {
+    const dir = path.join('src', 'pages');
+    replaceLinksInFile({
+        file,
+        linkMap: getLinkMap(fileMap, dir),
+        getFindPattern: (from) => `(['"]?path['"]?\\s*:\\s*['"])(/|./)?(${from})(#[^'"]*)?(['"])`,
+        getReplacePattern: (to) => `$1$2${to}$4$5`,
+    });
+}
+
 function renameLinksInMarkdownFile(fileMap, file) {
     const dir = path.dirname(file);
     replaceLinksInFile({ 
@@ -112,16 +122,6 @@ function renameLinksInRedirectsFile(fileMap, pathPrefix) {
         linkMap: getLinkMap(fileMap, dir),
         getFindPattern: (from) => `(['"]?)(Source|Destination)(['"]?\\s*:\\s*['"])(${pathPrefix}${removeFileExtension(from)})(/?)(#[^'"]*)?(['"])`,
         getReplacePattern: (to) => `$1$2$3${pathPrefix}${removeFileExtension(to)}$5$6$7`,
-    });
-}
-
-function renameLinksInGatsbyConfigFile(fileMap, file) {
-    const dir = path.join('src', 'pages');
-    replaceLinksInFile({
-        file,
-        linkMap: getLinkMap(fileMap, dir),
-        getFindPattern: (from) => `(['"]?path['"]?\\s*:\\s*['"])(/|./)?(${from})(#[^'"]*)?(['"])`,
-        getReplacePattern: (to) => `$1$2${to}$4$5`,
     });
 }
 

--- a/scriptUtils.js
+++ b/scriptUtils.js
@@ -29,7 +29,7 @@ function writeRedirectionsFile(data) {
 function getFiles(fileExtensions) {
     const fileExtensionsPattern = fileExtensions.join('|');
     return globSync(__dirname + `/src/pages/**/*+(${fileExtensionsPattern})`)
-        .map(f => path.resolve(f));
+        .map(f => path.relative(__dirname, f));
 }
 
 function getDeployableFiles() {
@@ -41,13 +41,12 @@ function getMarkdownFiles() {
     return getFiles(['.md']);
 }
 
-function removeFileExtension(file, renameBaseWithoutExt = name => name) {
+function removeFileExtension(file) {
     const base = path.basename(file);
     const ext = path.extname(file);
     const end = file.length - base.length;
     const baseWithoutExt = base.substring(0, base.length - ext.length);
-    const newBaseWithoutExt = renameBaseWithoutExt(baseWithoutExt);
-    return `${file.substring(0, end)}${newBaseWithoutExt}`
+    return `${file.substring(0, end)}${baseWithoutExt}`
 }
 
 const getFindPatternForMarkdownFiles = (from) => `(\\[[^\\]]*]\\()(/|./)?(${from})(#[^\\()]*)?(\\))`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Previously, `renameFiles` only renamed filenames. This PR will also [rename dirs](https://github.com/AdobeDocs/adp-devsite-github-actions-test/pull/33/commits/16983c322343ba6b2d97b7101e7ffa02021263ac), so the file can be published to EDS.
- Previously, some links in `redirects.json` didn't get renamed because they point to files that don't exist. This PR will [rename links to "phantom" files](https://github.com/AdobeDocs/adp-devsite-github-actions-test/pull/33/commits/cbba00a10574a6898f498bbaefad27ae4808e15c) because they need to be in `redirects.json` for the Gatsby-style redirects to work.
- Refactor, i.e. [rearrange the functions](https://github.com/AdobeDocs/adp-devsite-github-actions-test/pull/33/commits/1632e0c99aada51626f529510a811cbc1ddc5714), so that related functions are next to each other.

## Related Issue
https://jira.corp.adobe.com/browse/DEVSITE-1562

## Motivation and Context
https://jira.corp.adobe.com/browse/DEVSITE-1562?focusedId=47771821&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-47771821

## How Has This Been Tested?
1. git checkout devsite-1562-rename-dirs-test
2. Notice file `src/pages/guides/AppConfig.types/enumerations/text_to.image-app-version.md` exists
3. yarn renameFiles
4. Notice file renamed to `src/pages/guides/app-config-types/enumerations/text-to-image-app-version.md`

## Longer Test
1. git checkout devsite-1562-rename-dirs-test


<img width="389" alt="Screenshot 2025-05-21 at 8 40 11 PM" src="https://github.com/user-attachments/assets/f89e8df2-cc2a-4cd9-a022-d150a1ced152" />


2. yarn normalizeLinks > commit
<img width="1297" alt="Screenshot 2025-05-21 at 8 41 19 PM" src="https://github.com/user-attachments/assets/b9a3c0a9-6488-4fd5-ac26-10b4d55167c5" />

<img width="1295" alt="Screenshot 2025-05-21 at 8 41 33 PM" src="https://github.com/user-attachments/assets/707b90e5-7544-41a6-bca1-aa1e525ab063" />



3. open up `redirects.json` > format > commit
4. yarn renameFiles > open up `redirects.json` > format > commit




<img width="481" alt="Screenshot 2025-05-21 at 8 57 21 PM" src="https://github.com/user-attachments/assets/98e77b57-38a5-43ad-8ecb-8172c3a5e416" />




<img width="745" alt="Screenshot 2025-05-21 at 8 57 43 PM" src="https://github.com/user-attachments/assets/a800f15d-07a4-4c41-a6cd-660cfc0011c4" />





<img width="1297" alt="Screenshot 2025-05-21 at 8 43 13 PM" src="https://github.com/user-attachments/assets/555208d9-1877-4d3b-adae-9feba135cabc" />


<img width="1294" alt="Screenshot 2025-05-21 at 8 43 47 PM" src="https://github.com/user-attachments/assets/2b121d73-29a0-4156-85ef-4bc3fc7ff42a" />

<img width="1546" alt="Screenshot 2025-05-21 at 8 44 34 PM" src="https://github.com/user-attachments/assets/ffd55a3e-acdf-49a0-8714-fddb2822c83f" />


6. (tested on my own branch where I ran steps 1 - 3): `curl -XPOST -vi --header "x-content-source-authorization: devsite-1562-rename-dirs-test-2" https://admin.hlx.page/preview/adobedocs/adp-devsite-stage/stage/github-actions-test/Guides/app-config-types/enumerations/text-to-image-app-version.md`


<img width="959" alt="Screenshot 2025-05-21 at 8 48 27 PM" src="https://github.com/user-attachments/assets/52aaca75-a974-489e-a40c-38cd3f197730" />

