### PR TITLE
fix: check dir existence before delete

### DIFF
--- a/renameFiles.js
+++ b/renameFiles.js
@@ -137,11 +137,12 @@ function renameLinksInMarkdownFile(fileMap, file) {
 function renameLinksInRedirectsFile(fileMap, pathPrefix) {
     const file = getRedirectionsFilePath();
     const dir = path.dirname(file);
+    const linkMap = getLinkMap(fileMap, dir);
 
     // rename redirects for correct paths
     replaceLinksInFile({
         file,
-        linkMap: getLinkMap(fileMap, dir),
+        linkMap,
         getFindPattern: (from) => `(['"]?)(Source|Destination)(['"]?\\s*:\\s*['"])(${pathPrefix}${toUrl(from)})(#[^'"]*)?(['"])`,
         getReplacePattern: (to) => `$1$2$3${pathPrefix}${toUrl(to)}$5$6`,
     });
@@ -150,13 +151,13 @@ function renameLinksInRedirectsFile(fileMap, pathPrefix) {
     // (handle non-existent paths added by 'buildRedirections.js')
     replaceLinksInFile({
         file,
-        linkMap: getLinkMap(fileMap, dir),
+        linkMap,
         getFindPattern: (from) => `(['"]?)(Source)(['"]?\\s*:\\s*['"])(${pathPrefix}${removeTrailingSlash(toUrl(from))})(#[^'"]*)?(['"])`,
         getReplacePattern: (to) => `$1$2$3${pathPrefix}${removeTrailingSlash(toUrl(to))}$5$6`,
     });
     replaceLinksInFile({
         file,
-        linkMap: getLinkMap(fileMap, dir),
+        linkMap,
         getFindPattern: (from) => `(['"]?)(Source)(['"]?\\s*:\\s*['"])(${pathPrefix}${removeTrailingSlash(toUrl(from))}/index)(#[^'"]*)?(['"])`,
         getReplacePattern: (to) => `$1$2$3${pathPrefix}${removeTrailingSlash(toUrl(to))}/index$5$6`,
     });
@@ -166,7 +167,7 @@ function renameLinksInRedirectsFile(fileMap, pathPrefix) {
     // (handle non-existent paths added by 'buildRedirections.js')
     replaceLinksInFile({
         file,
-        linkMap: getLinkMap(fileMap, dir),
+        linkMap,
         getFindPattern: (from) => `(['"]?)(Source)(['"]?\\s*:\\s*['"])(${pathPrefix}${toUrl(from)}/)(#[^'"]*)?(['"])`,
         getReplacePattern: (to) => `$1$2$3${pathPrefix}${toUrl(to)}/$5$6`,
     });

--- a/renameFiles.js
+++ b/renameFiles.js
@@ -213,7 +213,9 @@ function renameFiles(map) {
     // delete old dirs
     map.forEach((_, from) => {
         const fromDir = path.dirname(from);
-        deleteEmptyDirectoryUpwards(fromDir, __dirname);
+        if (!fs.existsSync(fromDir)) { 
+            deleteEmptyDirectoryUpwards(fromDir, __dirname);
+        }
     });
 }
 


### PR DESCRIPTION
## Description

- [fix](https://github.com/AdobeDocs/adp-devsite-github-actions-test/commit/dd0d5751fb5a4545bc1edf8d06c916bb142313aa): only delete dir if it exists
- [refactor](https://github.com/AdobeDocs/adp-devsite-github-actions-test/commit/1a150b345a0be8a2e5cff8168ebea2b1c3295583): store re-computed object in a variable

## Related Issue
https://jira.corp.adobe.com/browse/DEVSITE-1562

## Before
<img width="784" alt="Screenshot 2025-05-22 at 11 53 36 AM" src="https://github.com/user-attachments/assets/dfb16414-3356-41f9-ba10-6c390fd78d30" />

## After
<img width="412" alt="Screenshot 2025-05-22 at 11 53 43 AM" src="https://github.com/user-attachments/assets/d56d3c88-ff1c-49b3-89a0-bbce59900954" />
