### PR TITLE
fix: delete empty dirs

### DIFF
--- a/renameFiles.js
+++ b/renameFiles.js
@@ -214,7 +214,7 @@ function renameFiles(map) {
     // delete old dirs
     map.forEach((_, from) => {
         const fromDir = path.dirname(from);
-        if (!fs.existsSync(fromDir)) { 
+        if (fs.existsSync(fromDir)) { 
             deleteEmptyDirectoryUpwards(fromDir, __dirname);
         }
     });


### PR DESCRIPTION
## Description

Empty dirs aren't deleted due to incorrect condition

## Related Issue

https://jira.corp.adobe.com/browse/DEVSITE-1627?focusedId=48008640&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-48008640
