### PR TITLE
fix: only read gatsby-config as fallback

### DIFF
--- a/renameFiles.js
+++ b/renameFiles.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('node:fs');
-const { pathPrefix: pathPrefixFromGatsbyConfig } = require('./gatsby-config.js');
 const {
+    getPathPrefix,
     readRedirectionsFile,
     writeRedirectionsFile,
     getRedirectionsFilePath,
@@ -45,39 +45,6 @@ function removeTrailingSlash(str) {
         str = str.substring(0, index);
     }
     return str;
-}
-
-function getPathPrefixFromConfig() {
-    const CONFIG_PATH = path.join('src', 'pages', 'config.md');
-    if (!fs.existsSync(CONFIG_PATH)) {
-        return null;
-    }
-
-    const data = fs.readFileSync(CONFIG_PATH).toString();
-    if (!data) {
-        return null;
-    }
-
-    const lines = data.split('\n');
-
-    // find the pathPrefix key
-    const keyIndex = lines.findIndex((line) => new RegExp(/\s*-\s*pathPrefix:/).test(line));
-    if (keyIndex < 0) {
-        return null;
-    }
-
-    // find the pathPrefix value
-    const line = lines.slice(keyIndex + 1)?.find((line) => new RegExp(/\s*-/).test(line));
-    if (!line) {
-        null;
-    }
-
-    // extract pathPrefix
-    const pathPrefixLine = line.match(new RegExp(/(\s*-\s*)(\S*)(\s*)/));
-    if (!pathPrefixLine) {
-        return null;
-    }
-    return pathPrefixLine[2];
 }
 
 function toEdsPath(file) {
@@ -229,7 +196,7 @@ try {
     });
 
     const redirectsFile = getRedirectionsFilePath();
-    const pathPrefix = getPathPrefixFromConfig() ?? pathPrefixFromGatsbyConfig;
+    const pathPrefix = getPathPrefix();
     if (fs.existsSync(redirectsFile)) {
         renameLinksInRedirectsFile(fileMap, pathPrefix);
         appendRedirects(fileMap, pathPrefix);

--- a/scriptUtils.js
+++ b/scriptUtils.js
@@ -1,6 +1,44 @@
 const path = require('path');
 const fs = require('node:fs');
 const { globSync } = require('glob');
+const { pathPrefix: pathPrefixFromGatsbyConfig } = require('./gatsby-config.js');
+
+function getPathPrefixFromConfig() {
+    const CONFIG_PATH = path.join('src', 'pages', 'config.md');
+    if (!fs.existsSync(CONFIG_PATH)) {
+        return null;
+    }
+
+    const data = fs.readFileSync(CONFIG_PATH).toString();
+    if (!data) {
+        return null;
+    }
+
+    const lines = data.split('\n');
+
+    // find the pathPrefix key
+    const keyIndex = lines.findIndex((line) => new RegExp(/\s*-\s*pathPrefix:/).test(line));
+    if (keyIndex < 0) {
+        return null;
+    }
+
+    // find the pathPrefix value
+    const line = lines.slice(keyIndex + 1)?.find((line) => new RegExp(/\s*-/).test(line));
+    if (!line) {
+        null;
+    }
+
+    // extract pathPrefix
+    const pathPrefixLine = line.match(new RegExp(/(\s*-\s*)(\S*)(\s*)/));
+    if (!pathPrefixLine) {
+        return null;
+    }
+    return pathPrefixLine[2];
+}
+
+function getPathPrefix() {
+    return getPathPrefixFromConfig() ?? pathPrefixFromGatsbyConfig;
+}
 
 function getRedirectionsFilePath() {
     const redirectionsFilePath = path.join(__dirname, 'src', 'pages', 'redirects.json');
@@ -61,6 +99,7 @@ function replaceLinksInFile({ file, linkMap, getFindPattern, getReplacePattern }
 }
 
 module.exports = {
+    getPathPrefix,
     getRedirectionsFilePath,
     readRedirectionsFile,
     writeRedirectionsFile,

--- a/scriptUtils.js
+++ b/scriptUtils.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const fs = require('node:fs');
 const { globSync } = require('glob');
-const { pathPrefix: pathPrefixFromGatsbyConfig } = require('./gatsby-config.js');
 
 function getPathPrefixFromConfig() {
     const CONFIG_PATH = path.join('src', 'pages', 'config.md');
@@ -36,8 +35,13 @@ function getPathPrefixFromConfig() {
     return pathPrefixLine[2];
 }
 
+function getPathPrefixFromGatsbyConfig() {
+    const { pathPrefix } = require('./gatsby-config.js');
+    return pathPrefix;
+}
+
 function getPathPrefix() {
-    return getPathPrefixFromConfig() ?? pathPrefixFromGatsbyConfig;
+    return getPathPrefixFromConfig() ?? getPathPrefixFromGatsbyConfig();
 }
 
 function getRedirectionsFilePath() {


### PR DESCRIPTION
## Description

**Issue:** 
Script is assuming gatsby-config.js always exists

**Fix:**
Only read `gatsby-config.js` as fallback

## How Has This Been Tested?
1. Delete `gatsby-config.js`
2. `yarn renameFiles`
3. Confirm no `Error: Cannot find module './gatsby-config.js'`

## Screenshots (if appropriate):
**Before:**
<img width="645" alt="Screenshot 2025-06-23 at 8 49 21 AM" src="https://github.com/user-attachments/assets/3b919a83-fd98-4e48-ab6f-53faa575b9a7" />


**After:**
<img width="547" alt="Screenshot 2025-06-23 at 8 46 52 AM" src="https://github.com/user-attachments/assets/bec21e06-1fe3-45e8-8924-af3a3c691160" />
