### PR TITLE
feat: keep old sources when renaming redirects

### DIFF
--- a/scriptUtils.js
+++ b/scriptUtils.js
@@ -94,12 +94,17 @@ const getReplacePatternForMarkdownFiles = (to) => `$1$2${to}$4$5`;
 
 function replaceLinksInFile({ file, linkMap, getFindPattern, getReplacePattern }) {
     let data = fs.readFileSync(file, 'utf8');
+    data = replaceLinksInString({ string: data, linkMap, getFindPattern, getReplacePattern });
+    fs.writeFileSync(file, data, 'utf-8');
+}
+
+function replaceLinksInString({ string, linkMap, getFindPattern, getReplacePattern }) {
     linkMap.forEach((to, from) => {
         const find = getFindPattern(from);
         const replace = getReplacePattern(to);
-        data = data.replaceAll(new RegExp(find, 'gm'), replace);
+        string = string.replaceAll(new RegExp(find, 'gm'), replace);
     });
-    fs.writeFileSync(file, data, 'utf-8');
+    return string;
 }
 
 module.exports = {
@@ -113,4 +118,5 @@ module.exports = {
     getReplacePatternForMarkdownFiles,
     removeFileExtension,
     replaceLinksInFile,
+    replaceLinksInString,
 };


### PR DESCRIPTION
## Description
Keep old `Source`s when renaming `redirects.json`

## Related Issue

https://jira.corp.adobe.com/browse/DEVSITE-1718

## Motivation and Context
Previously, `renameFiles` would do two things to `redirects.json`:
1. Replace old names with new names
<img width="1378" alt="Screenshot 2025-06-25 at 11 56 25 AM" src="https://github.com/user-attachments/assets/f3e8f147-1f5b-49d6-90fb-0c17a1884dc4" />
2. Append redirects from old names to new names
<img width="1377" alt="Screenshot 2025-06-25 at 11 58 36 AM" src="https://github.com/user-attachments/assets/faf0ed47-5acf-423d-8f81-4b2db52b92cd" />


The issue with 1 is that because the old source `/github-actions-test/with.dot/` has been replaced with `/github-actions-test/with-dot/`, bookmarks to `/github-actions-test/with.dot/` will now 404.


This PR changes how 1 is done:

1.  Keeps instead of replaces the old source:

| source renamed? | destination renamed? | code | diff |
| --- | --- | --- | --- |
| &#x274C; | &#x274C; | https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/5a9407ff3abc84452da85c09d9187be9bd3ab87e/renameFiles.js#L160-L164 | ![](https://github.com/user-attachments/assets/523477e2-8aa9-410e-ac4b-98d385361dd3) |
| &#x274C; | &#x2705; | https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/5a9407ff3abc84452da85c09d9187be9bd3ab87e/renameFiles.js#L165-L169 | ![](https://github.com/user-attachments/assets/ce682052-588b-4419-9e51-765988d6a2ef) |
| &#x2705; | &#x274C; | https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/5a9407ff3abc84452da85c09d9187be9bd3ab87e/renameFiles.js#L170-L178 | ![](https://github.com/user-attachments/assets/2c628e22-c977-462f-9757-e0ea0ae7696d) |
| &#x2705; | &#x2705; | https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/5a9407ff3abc84452da85c09d9187be9bd3ab87e/renameFiles.js#L179-L187 | ![](https://github.com/user-attachments/assets/586a120c-f660-4b77-9a68-4b9d8ea5e47a) |

2. As before, append redirects from old names to new names
<img width="1559" alt="Screenshot 2025-06-25 at 1 45 23 PM" src="https://github.com/user-attachments/assets/4ae13833-0326-41c0-96d5-e7680e74be78" />



## How Has This Been Tested?

- git checkout devsite-1718-rename-redirects-test
- yarn renameFiles
