### PR TITLE
test(DEVSITE-2480): verify linter skips deleted files

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -11,7 +11,8 @@ permissions:
 
 jobs:
   comment:
-    uses: AdobeDocs/adp-devsite-workflow/.github/workflows/pr-comment-v3.yml@DEVSITE-2424
+    uses: AdobeDocs/adp-devsite-workflow/.github/workflows/pr-comment-v3.yml@DEVSITE-2480
     with:
       run_id: ${{ github.event.workflow_run.id }}
       event: ${{ github.event.workflow_run.event }}
+    secrets: inherit

--- a/src/pages/DEVSITE-2480-test.md
+++ b/src/pages/DEVSITE-2480-test.md
@@ -1,0 +1,8 @@
+---
+title: DEVSITE-2480 Test
+description: Test file to verify linter skips deleted files in PR validation
+---
+
+# DEVSITE-2480 Test
+
+This file tests that the PR linter correctly skips deleted files.

--- a/src/pages/DEVSITE-2480-test.md
+++ b/src/pages/DEVSITE-2480-test.md
@@ -1,8 +1,0 @@
----
-title: DEVSITE-2480 Test
-description: Test file to verify linter skips deleted files in PR validation
----
-
-# DEVSITE-2480 Test
-
-This file tests that the PR linter correctly skips deleted files.

--- a/src/pages/no-sidenav-1.md
+++ b/src/pages/no-sidenav-1.md
@@ -1,1 +1,0 @@
-This page isn't in `config.md subPages`, so it shouldn't have a sidenav.


### PR DESCRIPTION
## Summary

- Adds a new markdown file (`DEVSITE-2480-test.md`) to `src/pages/`
- Deletes an existing markdown file (`no-sidenav-1.md`) from `src/pages/`

This PR tests that the updated `lint-v3.yml` workflow (on branch `DEVSITE-2480` of `adp-devsite-workflow`) correctly skips deleted files when running the linter — only `DEVSITE-2480-test.md` should be linted, not the deleted `no-sidenav-1.md`.

## Test plan
- [ ] PR validation workflow triggers
- [ ] Linter runs only on `DEVSITE-2480-test.md`
- [ ] Deleted file `no-sidenav-1.md` is not passed to the linter
- [ ] Workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)